### PR TITLE
Capturing artifacts in GitHub action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,3 +19,22 @@ jobs:
 
       - name: Build
         run: ./build.sh
+
+      - name: Service and enclave artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: glove-service
+          path: |
+            target/release/service
+            target/release/glove.eif
+
+      - name: Enclave measurement artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: enclave_measurement
+          path: target/release/enclave_measurement.txt
+
+      - name: Adding measurement to summary
+        run: |
+          echo '### Enclave Image Measurement' >> $GITHUB_STEP_SUMMARY
+          cat target/release/enclave_measurement.txt >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ to provision the correct EC2 instance. Make sure to use x86-64, with the Nitro E
 Then install the [Nitro Enclaves CLI](https://docs.aws.amazon.com/enclaves/latest/user/nitro-enclave-cli-install.html).
 Make sure to allocate at least 512 MiB for the enclave.
 
-Make sure the `service` binary and the `glove.eif` files are in the same directoy. If you built using `build.sh` they
+Make sure the `service` binary and the `glove.eif` files are in the same directory. If you built using `build.sh` they
 will both be in `target/release`:
 
 ```shell
-target/release/service --address=<LISTEN> --proxy-secret-phrase=<SECRET PHRASE> --network-url=<URL>
+target/release/service --address=<LISTEN> --proxy-secret-phrase=<SECRET PHRASE> --node-endpoint=<URL>
 ```
 
-Run with `--help` to see example network endpoints for various chains.
+To understand what these arguments mean and others, you will need to first read the help with `--help`.
 
 You can check the enclave is running with:
 
@@ -59,9 +59,14 @@ start the enclave in debug mode and output to the console.
 > [!WARNING]
 > Debug mode is not secure and will be reflected in the enclave's remote attestation. Do not enable this in production.
 
-## Client CLI
+# Client CLI
 
-There is a CLI client for interacting with the Glove service from the command line:
+There is a CLI client for interacting with the Glove service from the command line. It is built alonside the Glove
+service and enclave with the `./build.sh` command (described above). To build it on a local machine:
+
+```shell
+cargo build --release --bin client
+```
 
 ```shell
 target/release/client --help
@@ -73,7 +78,7 @@ First join Glove with the `join-glove` command and then vote with `vote`.
 
 ## MacOS
 
-If building on MacOS, then use `cargo` directly rather than the build script. Only mock mode will be available.
+If building on MacOS, then use `cargo` directly rather than the `./build.sh` script. Only mock mode will be available.
 
 ## Regenerating the Substrate metadata
 

--- a/build.sh
+++ b/build.sh
@@ -18,6 +18,7 @@ glove_build_env cargo build --bins --workspace --exclude enclave -r
 glove_build_env touch --date='@0' target/x86_64-unknown-linux-musl/release/enclave
 glove_build_env docker build --no-cache -t glove-enclave -f enclave/Dockerfile .
 glove_build_env nitro-cli build-enclave --docker-uri glove-enclave --output-file target/release/glove.eif
+glove_build_env nitro-cli describe-eif --eif-path target/release/glove.eif | jq -r '.Measurements.PCR0' > target/release/enclave_measurement.txt
 docker cp glove-build-env:/glove/target .
 docker image rm glove-enclave > /dev/null
 docker rm -f glove-build-env > /dev/null

--- a/common/src/attestation.rs
+++ b/common/src/attestation.rs
@@ -144,7 +144,6 @@ impl GloveProofLite {
 #[derive(Debug, Clone, PartialEq, Encode, Decode)]
 pub enum AttestationBundleLocation {
     SubstrateRemark(ExtrinsicLocation),
-    // Http(String)
 }
 
 #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
The enclave measurement is also captured into a `enclave_measurement.txt` file.

The `--help` output of the service has also been improved, including renaming `--network-url` to `--node-endpoint`.