### PR TITLE
Role with testing ssh key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target/
 .idea/
 
 terraform.tfstate*
+devops/ansible/roles/extra_ssh


### PR DESCRIPTION
Role with testing ssh key. Needs to be run if the underling server is going to be replaced (e.g. new AMI).