### PR TITLE
Support signatures produced by Polkadot JS `signRaw`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,14 +1234,13 @@ checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "client"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "bigdecimal",
  "clap",
  "client-interface",
  "common",
- "hex",
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
@@ -1258,11 +1257,10 @@ dependencies = [
 
 [[package]]
 name = "client-interface"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "common",
- "hex",
  "parity-scale-codec",
  "rand",
  "reqwest",
@@ -1288,12 +1286,11 @@ checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "common"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "aws-nitro-enclaves-nsm-api",
  "flate2",
- "hex",
  "openssl",
  "parity-scale-codec",
  "rand",
@@ -1825,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "enclave"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "aws-nitro-enclaves-nsm-api",
@@ -1847,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "enclave-interface"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "common",
  "nix 0.27.1",
@@ -4703,7 +4700,7 @@ dependencies = [
 
 [[package]]
 name = "service"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -5613,7 +5610,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stress-tool"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 [workspace.package]
 homepage = "https://projectglove.io/"
 repository = "https://github.com/projectglove/glove-monorepo/"
-version = "0.0.7"
+version = "0.0.8"
 
 [workspace.dependencies]
 anyhow = "1.0.86"
@@ -50,7 +50,6 @@ cfg-if = "1.0.0"
 aws-nitro-enclaves-nsm-api = "0.4.0"
 aws-nitro-enclaves-cose = "0.5.2"
 openssl = "0.10.66"
-hex = "0.4.3"
 sha2 = "0.10.8"
 flate2 = "1.0.30"
 aws-config = "1.5.4"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Enclave Image successfully created.
 {
   "Measurements": {
     "HashAlgorithm": "Sha384 { ... }",
-    "PCR0": "2c655d5ba7f35e9e5208aff0670b9bee257cd9994cb957100fd8c9b4aa693a1d1c67f430d28c4f62a5372fe96d417d29",
+    "PCR0": "8ea5994148980786599301b4c583bf14d11fef3188e1496db2c7d3367a7abce2d96cee153434873ac7e26b21e1478270",
 ...
   }
 }
@@ -45,7 +45,7 @@ instructions on how to audit and verify the enclave code.
 
 > [!NOTE]
 > The enclave measurement for the latest build is
-> `2c655d5ba7f35e9e5208aff0670b9bee257cd9994cb957100fd8c9b4aa693a1d1c67f430d28c4f62a5372fe96d417d29`.
+> `8ea5994148980786599301b4c583bf14d11fef3188e1496db2c7d3367a7abce2d96cee153434873ac7e26b21e1478270`.
 
 # Glove mixing
 
@@ -148,8 +148,8 @@ unique identifier.
 
 #### `attestation_bundle`
 
-The attestation bundle of the enclave the service is using. This is a hex-encoded string (without the `0x` prefix),
-representing the [`AttestationBundle`](common/src/attestation.rs#L45) struct in
+The attestation bundle of the enclave the service is using. This is a hex string representing the
+[`AttestationBundle`](common/src/attestation.rs#L38) struct in
 [SCALE](https://docs.substrate.io/reference/scale-codec/) encoding.
 
 The attestation bundle is primarily used in Glove proofs when the enclave submits its mixed votes on-chain. It's
@@ -165,8 +165,8 @@ The version of the Glove service.
 {
   "proxy_account": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
   "network_name": "rococo",
-  "attestation_bundle": "6408de7737c59c238890533af25896a2c20608d8b380bb01029acb3927...",
-  "version": "0.0.7"
+  "attestation_bundle": "0x6408de7737c59c238890533af25896a2c20608d8b380bb01029acb3927...",
+  "version": "0.0.8"
 }
 ```
 
@@ -183,15 +183,15 @@ A JSON object with the following fields:
 
 #### `request`
 
-[SCALE-encoded](https://docs.substrate.io/reference/scale-codec/) [`VoteRequest`](common/src/lib.rs#L36) struct as a
-hex string (without the `0x` prefix).
+[SCALE-encoded](https://docs.substrate.io/reference/scale-codec/) [`VoteRequest`](common/src/lib.rs#L57) as a
+hex string.
 
 #### `signature`
 
 [SCALE-encoded](https://docs.substrate.io/reference/scale-codec/)
-[`MultiSignature`](https://docs.rs/sp-runtime/latest/sp_runtime/enum.MultiSignature.html) as a hex string (without the
-`0x` prefix). Signed by`VoteRequest.account`, the signature is of the `VoteRequest` in SCALE-encoded bytes, i.e. the
-`request` field without the hex-encoding.
+[`MultiSignature`](https://docs.rs/sp-runtime/latest/sp_runtime/enum.MultiSignature.html) as a hex string. The 
+signature is of the `VoteRequest` in SCALE-encoded bytes, i.e. the `request` field without the hex-encoding, signed by
+`VoteRequest.account`.
 
 #### Example
 
@@ -219,15 +219,15 @@ A JSON object with the following fields:
 
 #### `request`
 
-[SCALE-encoded](https://docs.substrate.io/reference/scale-codec/) [`RemoveVoteRequest`](client-interface/src/lib.rs#L374)
-struct as a hex string (without the `0x` prefix).
+[SCALE-encoded](https://docs.substrate.io/reference/scale-codec/) [`RemoveVoteRequest`](client-interface/src/lib.rs#L416)
+as a hex string.
 
 #### `signature`
 
 [SCALE-encoded](https://docs.substrate.io/reference/scale-codec/)
-[`MultiSignature`](https://docs.rs/sp-runtime/latest/sp_runtime/enum.MultiSignature.html) as a hex string (without the
-`0x` prefix). Signed by`RemoveVoteRequest.account`, the signature is of the `RemoveVoteRequest` in SCALE-encoded bytes,
-i.e. the `request` field without the hex-encoding.
+[`MultiSignature`](https://docs.rs/sp-runtime/latest/sp_runtime/enum.MultiSignature.html) as a hex string. The 
+signature is of the `RemoveVoteRequest` in SCALE-encoded bytes, i.e. the `request` field without the hex-encoding, 
+signed by `RemoveVoteRequest.account`,
 
 ### Response
 

--- a/client-interface/Cargo.toml
+++ b/client-interface/Cargo.toml
@@ -25,5 +25,4 @@ tracing.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
-hex.workspace = true
 rand.workspace = true

--- a/client-interface/src/lib.rs
+++ b/client-interface/src/lib.rs
@@ -11,7 +11,6 @@ use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use serde::{Deserialize, Serialize};
 use sp_core::crypto::AccountId32;
 use sp_runtime::{MultiAddress, MultiSignature};
-use sp_runtime::traits::Verify;
 use ss58_registry::{Ss58AddressFormat, Ss58AddressFormatRegistry, Token};
 use subxt::Error as SubxtError;
 use subxt::ext::scale_decode::DecodeAsType;
@@ -23,8 +22,8 @@ use subxt_signer::SecretUri;
 use subxt_signer::sr25519;
 use tokio::sync::Mutex;
 
+use common::{ExtrinsicLocation, verify_js_payload};
 use common::attestation::AttestationBundle;
-use common::ExtrinsicLocation;
 use metadata::proxy::events::ProxyExecuted;
 use metadata::referenda::storage::types::referendum_info_for::ReferendumInfoFor;
 use metadata::runtime_types::frame_support::traits::preimages::Bounded;
@@ -410,7 +409,7 @@ pub struct SignedRemoveVoteRequest {
 
 impl SignedRemoveVoteRequest {
     pub fn verify(&self) -> bool {
-        self.signature.verify(&*self.request.encode(), &self.request.account)
+        verify_js_payload(&self.signature, &self.request, &self.request.account)
     }
 }
 
@@ -430,6 +429,7 @@ mod tests {
     use rand::random;
     use serde_json::{json, Value};
     use sp_core::{ed25519, Pair};
+    use subxt_core::utils::to_hex;
     use subxt_signer::sr25519::dev;
 
     use common::attestation::{Attestation, AttestedData};
@@ -460,7 +460,7 @@ mod tests {
             json!({
                 "proxy_account": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
                 "network_name": "polkadot",
-                "attestation_bundle": hex::encode(&service_info.attestation_bundle.encode()),
+                "attestation_bundle": to_hex(&service_info.attestation_bundle.encode()),
                 "version": "1.0.0"
             })
         );

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -22,5 +22,4 @@ strum.workspace = true
 sp-core.workspace = true
 sp-runtime.workspace = true
 thiserror.workspace = true
-hex.workspace = true
 ss58-registry.workspace = true

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -21,7 +21,6 @@ sha2.workspace = true
 thiserror.workspace = true
 flate2.workspace = true
 subxt.workspace = true
-hex.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/common/src/nitro.rs
+++ b/common/src/nitro.rs
@@ -136,6 +136,7 @@ pub enum Error {
 mod tests {
     use aws_nitro_enclaves_cose::CoseSign1;
     use parity_scale_codec::Decode;
+    use sp_core::bytes::from_hex;
 
     use super::*;
 
@@ -145,9 +146,9 @@ mod tests {
     fn decode_and_verify_attestation() {
         let doc = Attestation::try_from(RAW_NITRO_ATTESTATION_BYTES).unwrap().verify().unwrap();
         println!("{:?}", doc);
-        assert_eq!(doc.pcrs.get(&0).unwrap().to_vec(), hex::decode("dd1c94beae9a589b37f6601ecf73c297ff0bf41a8872f737fabf3c9a2a96eb3b1dcdabc8e33ba1f7654b528518b8b9ed").unwrap());
-        assert_eq!(doc.pcrs.get(&1).unwrap().to_vec(), hex::decode("52b919754e1643f4027eeee8ec39cc4a2cb931723de0c93ce5cc8d407467dc4302e86490c01c0d755acfe10dbf657546").unwrap());
-        assert_eq!(doc.pcrs.get(&2).unwrap().to_vec(), hex::decode("35a4393a77e7f60a9eb28b974b400149e36fe07791a84b3285cb16f3fdeaf7503f98ecdf6cc800d0109166d82fc7052b").unwrap());
+        assert_eq!(doc.pcrs.get(&0).unwrap().to_vec(), from_hex("dd1c94beae9a589b37f6601ecf73c297ff0bf41a8872f737fabf3c9a2a96eb3b1dcdabc8e33ba1f7654b528518b8b9ed").unwrap());
+        assert_eq!(doc.pcrs.get(&1).unwrap().to_vec(), from_hex("52b919754e1643f4027eeee8ec39cc4a2cb931723de0c93ce5cc8d407467dc4302e86490c01c0d755acfe10dbf657546").unwrap());
+        assert_eq!(doc.pcrs.get(&2).unwrap().to_vec(), from_hex("35a4393a77e7f60a9eb28b974b400149e36fe07791a84b3285cb16f3fdeaf7503f98ecdf6cc800d0109166d82fc7052b").unwrap());
         assert_eq!(doc.user_data, None);
         assert_eq!(doc.public_key, None);
         assert_eq!(doc.nonce, None);

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -129,16 +129,8 @@ enum EnclaveMode {
     Mock
 }
 
-// TODO Test what an actual limit is on batched votes
-// TODO Load test with ~100 accounts voting on a single poll
 // TODO Probably need to specify API key for subscan
 // TODO Sign the enclave image
-
-// TODO Deal with RPC disconnect:
-//  2024-06-19T11:41:42.195924Z  WARN request{method=POST uri=/vote version=HTTP/1.1}: service: Subxt(Rpc(ClientError(RestartNeeded(Transport(connection closed
-//  Caused by:
-//  connection closed)))))
-
 // TODO Permantely ban accounts which vote directly
 // TODO Endpoint for poll end time and other info?
 
@@ -467,7 +459,6 @@ async fn mix_votes(context: &GloveContext, poll_index: u32) {
             Ok(true) => continue,
             Ok(false) => break,
             Err(mixing_error) => {
-                // TODO Reconnect on NotConnected IO error: Io(Os { code: 107, kind: NotConnected, message: "Transport endpoint is not connected" })
                 warn!("Error mixing votes: {:?}", mixing_error);
                 break;
             }


### PR DESCRIPTION
`signRaw` silently wraps the raw bytes with `<Bytes>` and `</Bytes>` before signing it. The `verify()` functions for `SignedVoteRequest` and `SignedRemoveVoteRequest` will try to verify with and without this wrapping to support both cases.

The REST API has also been updated to be support hex strings beginning with `0x`.