### PR TITLE
Subscan API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,13 @@ Make sure the `service` binary and the `glove.eif` file are in the same director
 will both be in `target/release`:
 
 ```shell
-target/release/service --address=<LISTEN> --proxy-secret-phrase=<SECRET PHRASE> --node-endpoint=<URL> dynamodb --table-name=<GLOVE TABLE>
+target/release/service --address=<LISTEN> --proxy-secret-phrase=<SECRET PHRASE> --node-endpoint=<URL> --subscan-api-key=<API KEY> dynamodb --table-name=<GLOVE TABLE>
 ```
 
-To understand what these arguments mean and others, you will need to first read the help with `--help`.
+The service makes use of [Subscan](https://support.subscan.io/) and it is recommended an API key be provided, though 
+not required.
+
+Full documenation of the arguments, along with other flags, can be found with `--help`.
 
 You can check the enclave is running with:
 

--- a/client/src/verify.rs
+++ b/client/src/verify.rs
@@ -27,7 +27,6 @@ pub struct VerifiedGloveProof {
     pub attested_data: AttestedData
 }
 
-// TODO API for checking EnclaveInfo for expected measurements
 impl VerifiedGloveProof {
     pub fn get_assigned_balance(&self, account: &AccountId32) -> Option<AssignedBalance> {
         self.result
@@ -246,5 +245,3 @@ pub enum Error {
     #[error("Invalid attestation: {0}")]
     Attestation(#[from] attestation::Error)
 }
-
-// TODO Tests

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -25,4 +25,3 @@ subxt.workspace = true
 [dev-dependencies]
 serde_json.workspace = true
 subxt-signer.workspace = true
-# TODO client-interface and enclave-interface should be merged into common but behind feature flags

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -74,6 +74,10 @@ struct Args {
     #[arg(long, verbatim_doc_comment)]
     node_endpoint: String,
 
+    /// API key to use when querying Subscan.
+    #[arg(long, verbatim_doc_comment)]
+    subscan_api_key: Option<String>,
+
     /// The storage to use for the service.
     #[clap(subcommand, verbatim_doc_comment)]
     storage: Storage,
@@ -129,7 +133,6 @@ enum EnclaveMode {
     Mock
 }
 
-// TODO Probably need to specify API key for subscan
 // TODO Sign the enclave image
 // TODO Permantely ban accounts which vote directly
 // TODO Endpoint for poll end time and other info?
@@ -196,7 +199,7 @@ async fn main() -> anyhow::Result<()> {
         state: GloveState::default()
     });
 
-    let subscan = Subscan::new(glove_context.network.network_name.clone());
+    let subscan = Subscan::new(glove_context.network.network_name.clone(), args.subscan_api_key);
     if args.regular_mix {
         warn!("Regular mixing of votes is enabled. This is not suitable for production.");
     } else {
@@ -532,9 +535,6 @@ async fn submit_glove_result_on_chain(
     signed_requests: &Vec<SignedVoteRequest>,
     signed_glove_result: SignedGloveResult
 ) -> Result<(), ProxyError> {
-    // TODO Should the enclave produce the extrinic calls structs? It would prove the enclave
-    //  intiated the abstain votes. Otherwise, users are trusting the host service is correctly
-    //  interpreting the enclave's None mixing output.
     let mut batched_calls = Vec::with_capacity(signed_requests.len() + 1);
 
     let glove_result = &signed_glove_result.result;

--- a/stress-tool/src/main.rs
+++ b/stress-tool/src/main.rs
@@ -167,7 +167,7 @@ async fn extrinsic(extrinsic_location: ExtrinsicLocation, args: Args) -> Result<
         .send().await?
         .error_for_status()?
         .json::<ServiceInfo>().await?;
-    let subscan = Subscan::new(service_info.network_name);
+    let subscan = Subscan::new(service_info.network_name, None);
     match subscan.get_extrinsic(extrinsic_location).await? {
         Some(extrinsic) => println!("{:#?}", extrinsic),
         None => bail!("Extrinsic not found")


### PR DESCRIPTION
Subscan API key can be provided to the service and client.

Also, removed the `--await-glove-proof` flag from the `vote` command of the client. It became superfluous with the `verify-vote` command.