### PR TITLE
Service option to exclude polls from being voted on which belong to certain tracks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,7 +1234,7 @@ checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "client"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "client-interface"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "common",
@@ -1286,7 +1286,7 @@ checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "common"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "aws-nitro-enclaves-nsm-api",
@@ -1822,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "enclave"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "aws-nitro-enclaves-nsm-api",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "enclave-interface"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "common",
  "nix 0.27.1",
@@ -4700,7 +4700,7 @@ dependencies = [
 
 [[package]]
 name = "service"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -5610,7 +5610,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stress-tool"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 [workspace.package]
 homepage = "https://projectglove.io/"
 repository = "https://github.com/projectglove/glove-monorepo/"
-version = "0.0.8"
+version = "0.0.9"
 
 [workspace.dependencies]
 anyhow = "1.0.86"

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -114,6 +114,7 @@ pub struct GloveContext {
     pub enclave_handle: EnclaveHandle,
     pub attestation_bundle: AttestationBundle,
     pub network: CallableSubstrateNetwork,
+    pub exclude_tracks: HashSet<u16>,
     pub regular_mix_enabled: bool,
     pub state: GloveState,
 }


### PR DESCRIPTION
`--exclude-tracks` is a comma separated list of track IDs. Vote requests for such tracks return with a `TrackNotAllowed` bad request error.

If a track is excluded and there are already vote requests for the track, then a warning is issued but the requests will be mixed. This is to honour the `/vote` request having previously returned HTTP OK. However, further vote requests will not be allowed.