### PR TITLE
Using Subscan for parsing extrinsics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,7 +1234,7 @@ checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "client"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -1244,6 +1244,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
+ "serde",
  "sp-core 33.0.1",
  "sp-runtime 37.0.0",
  "ss58-registry",
@@ -1257,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "client-interface"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "common",
@@ -1286,7 +1287,7 @@ checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "common"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "aws-nitro-enclaves-nsm-api",
@@ -1822,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "enclave"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "aws-nitro-enclaves-nsm-api",
@@ -1844,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "enclave-interface"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "common",
  "nix 0.27.1",
@@ -4700,7 +4701,7 @@ dependencies = [
 
 [[package]]
 name = "service"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -5610,7 +5611,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stress-tool"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 [workspace.package]
 homepage = "https://projectglove.io/"
 repository = "https://github.com/projectglove/glove-monorepo/"
-version = "0.0.9"
+version = "0.0.10"
 
 [workspace.dependencies]
 anyhow = "1.0.86"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Enclave Image successfully created.
 {
   "Measurements": {
     "HashAlgorithm": "Sha384 { ... }",
-    "PCR0": "8ea5994148980786599301b4c583bf14d11fef3188e1496db2c7d3367a7abce2d96cee153434873ac7e26b21e1478270",
+    "PCR0": "4d132e40ed8d6db60d01d0116c34a4a92914de73d668821b6e019b72ae152b1180ef7c8a378e6c1925fe2bcb31c0ec80",
 ...
   }
 }
@@ -45,7 +45,7 @@ instructions on how to audit and verify the enclave code.
 
 > [!NOTE]
 > The enclave measurement for the latest build is
-> `8ea5994148980786599301b4c583bf14d11fef3188e1496db2c7d3367a7abce2d96cee153434873ac7e26b21e1478270`.
+> `4d132e40ed8d6db60d01d0116c34a4a92914de73d668821b6e019b72ae152b1180ef7c8a378e6c1925fe2bcb31c0ec80`.
 
 # Glove mixing
 

--- a/client-interface/Cargo.toml
+++ b/client-interface/Cargo.toml
@@ -17,12 +17,12 @@ subxt-core.workspace = true
 subxt-signer.workspace = true
 thiserror.workspace = true
 serde.workspace = true
+serde_json.workspace = true
+serde_with.workspace = true
 parity-scale-codec.workspace = true
 tokio = { workspace = true, features = ["sync"] }
-serde_with.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 tracing.workspace = true
 
 [dev-dependencies]
-serde_json.workspace = true
 rand.workspace = true

--- a/client-interface/src/subscan.rs
+++ b/client-interface/src/subscan.rs
@@ -1,11 +1,13 @@
 use std::fmt::Debug;
+use std::ops::Deref;
 use std::time::Duration;
 
 use reqwest::header::{HeaderMap, RETRY_AFTER};
-use serde::{Deserialize, Serialize};
+use serde::{de, Deserialize, Deserializer, Serialize};
 use serde::de::DeserializeOwned;
 use serde_with::DisplayFromStr;
 use serde_with::serde_as;
+use sp_core::bytes::from_hex;
 use sp_runtime::AccountId32;
 use tokio::time::sleep;
 use tracing::warn;
@@ -112,18 +114,14 @@ async fn handle_error(
     let retry_after = headers
         .get(RETRY_AFTER)
         .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.parse::<u64>().ok());
-    match retry_after {
-        Some(retry_after) => {
-            warn!("Rate limited, retrying after {} seconds ({:?})", retry_after, request);
-            sleep(Duration::from_secs(retry_after)).await;
-            Ok(())
-        }
-        None => Err(Error::Api {
+        .and_then(|v| v.parse::<u64>().ok())
+        .ok_or_else(|| Error::Api {
             code: api_response.code,
             message: api_response.message.clone(),
-        })
-    }
+        })?;
+    warn!("Rate limited, retrying after {} seconds ({:?})", retry_after, request);
+    sleep(Duration::from_secs(retry_after)).await;
+    Ok(())
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -190,7 +188,140 @@ struct ExtrinsicResponse {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct ExtrinsicDetail {
-    pub account_display: Option<Account>
+    pub account_display: Option<Account>,
+    pub call_module: String,
+    pub call_module_function: String,
+    pub params: Vec<ExtrinsicParam>
+}
+
+impl ExtrinsicDetail {
+    pub fn account_address(&self) -> Option<AccountId32> {
+        self.account_display.as_ref().map(|account| account.address.clone())
+    }
+
+    pub fn is_extrinsic(&self, call_module: &str, call_module_function: &str) -> bool {
+        self.call_module.to_ascii_lowercase() == call_module &&
+            self.call_module_function.to_ascii_lowercase() == call_module_function
+    }
+
+    pub fn get_param(&self, name: &str) -> Option<ExtrinsicParam> {
+        self.params.iter().find(|param| param.name == name).cloned()
+    }
+
+    pub fn get_param_as<T: DeserializeOwned>(&self, name: &str) -> Option<T> {
+        self.get_param(name).and_then(|param| param.value_as::<T>().ok())
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ExtrinsicParam {
+    pub name: String,
+    pub value: serde_json::Value
+}
+
+impl ExtrinsicParam {
+    pub fn value_as<T: DeserializeOwned>(self) -> Result<T, serde_json::Error> {
+        serde_json::from_value(self.value)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(transparent)]
+pub struct HexString {
+    #[serde(deserialize_with = "hex_deserialize")]
+    pub value: Vec<u8>
+}
+
+impl Deref for HexString {
+    type Target = Vec<u8>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl AsRef<[u8]> for HexString {
+    fn as_ref(&self) -> &[u8] {
+        &self.value
+    }
+}
+
+#[derive(Debug, PartialEq, Deserialize)]
+pub enum MultiAddress {
+    Id(AccountId32Ext)
+}
+
+#[serde_as]
+#[derive(Debug, PartialEq, Deserialize)]
+#[serde(transparent)]
+pub struct AccountId32Ext {
+    #[serde_as(as = "DisplayFromStr")]
+    pub value: AccountId32
+}
+
+impl Deref for AccountId32Ext {
+    type Target = AccountId32;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl From<AccountId32> for AccountId32Ext {
+    fn from(value: AccountId32) -> Self {
+        Self { value }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RuntimeCall {
+    pub call_module: String,
+    pub call_name: String,
+    pub params: Vec<ExtrinsicParam>
+}
+
+impl RuntimeCall {
+    pub fn is_extrinsic(&self, call_module: &str, call_module_function: &str) -> bool {
+        self.call_module.to_ascii_lowercase() == call_module &&
+            self.call_name.to_ascii_lowercase() == call_module_function
+    }
+
+    pub fn get_param(&self, name: &str) -> Option<ExtrinsicParam> {
+        self.params.iter().find(|param| param.name == name).cloned()
+    }
+
+    pub fn get_param_as<T: DeserializeOwned>(&self, name: &str) -> Option<T> {
+        self.get_param(name).and_then(|param| param.value_as::<T>().ok())
+    }
+}
+
+#[derive(Debug, PartialEq, Deserialize)]
+pub enum AccountVote {
+    Standard(StandardAccountVote),
+    SplitAbstain(SplitAbstainAccountVote)
+}
+
+#[serde_as]
+#[derive(Debug, PartialEq, Deserialize)]
+pub struct StandardAccountVote {
+    #[serde_as(as = "DisplayFromStr")]
+    pub balance: u128,
+    pub vote: u8
+}
+
+#[serde_as]
+#[derive(Debug, PartialEq, Deserialize)]
+pub struct SplitAbstainAccountVote {
+    #[serde_as(as = "DisplayFromStr")]
+    pub aye: u128,
+    #[serde_as(as = "DisplayFromStr")]
+    pub nay: u128,
+    #[serde_as(as = "DisplayFromStr")]
+    pub abstain: u128
+}
+
+fn hex_deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<u8>, D::Error> {
+    from_hex(&String::deserialize(deserializer)?).map_err(|e| de::Error::custom(e))
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -201,5 +332,66 @@ pub enum Error {
     Api {
         code: i64,
         message: String,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use subxt_core::utils::to_hex;
+
+    use super::*;
+
+    #[test]
+    fn hex_string() {
+        let json = r#"
+            {
+              "name": "remark",
+              "type": "Vec<U8>",
+              "value": "0x01050301c000965d770664c93693f56f70c9"
+            }
+"#;
+        let extrinsic_param = serde_json::from_str::<ExtrinsicParam>(json).unwrap();
+        assert_eq!(extrinsic_param.name, "remark");
+        let hex_string = extrinsic_param.value_as::<HexString>().unwrap();
+        assert_eq!(to_hex(hex_string), "0x01050301c000965d770664c93693f56f70c9");
+    }
+
+    #[test]
+    fn multi_address() {
+        let json = r#"
+            {
+              "name": "real",
+              "type": "sp_runtime:multiaddress:MultiAddress",
+              "value": {
+                "Id": "0xf40f4316f0adec098c14637d132a827ce6f36c930aca32a56a2cc65f7177be2b"
+              }
+            }
+"#;
+        let extrinsic_param = serde_json::from_str::<ExtrinsicParam>(json).unwrap();
+        assert_eq!(extrinsic_param.name, "real");
+        let multi_address = extrinsic_param.value_as::<MultiAddress>().unwrap();
+        assert_eq!(multi_address, MultiAddress::Id(AccountId32::from_str("0xf40f4316f0adec098c14637d132a827ce6f36c930aca32a56a2cc65f7177be2b").unwrap().into()));
+    }
+
+    #[test]
+    fn standard_account_vote() {
+        let json = r#"
+            {
+              "name": "vote",
+              "type": "pallet_conviction_voting:vote:AccountVote",
+              "value": {
+                "Standard": {
+                  "balance": "420964038408",
+                  "vote": 2
+                }
+              }
+            }
+"#;
+        let extrinsic_param = serde_json::from_str::<ExtrinsicParam>(json).unwrap();
+        assert_eq!(extrinsic_param.name, "vote");
+        let account_vote = extrinsic_param.value_as::<AccountVote>().unwrap();
+        assert_eq!(account_vote, AccountVote::Standard(StandardAccountVote { balance: 420964038408, vote: 2 }));
     }
 }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -23,3 +23,4 @@ sp-core.workspace = true
 sp-runtime.workspace = true
 thiserror.workspace = true
 ss58-registry.workspace = true
+serde.workspace = true

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -32,8 +32,7 @@ use Command::{Info, JoinGlove, LeaveGlove, RemoveVote, VerifyVote, Vote};
 use common::{attestation, Conviction, SignedVoteRequest, VoteRequest};
 use common::attestation::{Attestation, EnclaveInfo};
 use RuntimeError::Proxy;
-
-use crate::verify::try_verify_glove_result;
+use verify::try_verify_glove_result;
 
 pub mod verify;
 
@@ -170,13 +169,11 @@ async fn verify_vote(service_info: ServiceInfo, cmd: VerifyVoteCmd) -> Result<Su
             bail!("Poll is no longer active and Glove proxy did not vote")
         }
     };
-    let Some(extrinsic) = network.get_extrinsic(vote.extrinsic_index).await? else {
-        bail!("Unable to find vote extrinsic at {}", vote.extrinsic_index)
-    };
     let verification_result = try_verify_glove_result(
         &network,
-        &extrinsic,
-        &service_info.proxy_account,
+        &subscan,
+        vote.extrinsic_index,
+        service_info.proxy_account,
         cmd.poll_index
     ).await;
     let verified_glove_proof = match verification_result {

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -58,7 +58,7 @@ impl VoterLookup {
                 Entry::Occupied(entry) => entry.get().clone(),
                 Entry::Vacant(entry) => {
                     if let Some(extrinsic) = subscan.get_extrinsic(vote.extrinsic_index).await? {
-                        entry.insert(extrinsic.account_display.map(|a| a.address)).clone()
+                        entry.insert(extrinsic.account_address()).clone()
                     } else {
                         warn!("Extrinsic not found: {:?}", vote.extrinsic_index);
                         entry.insert(None).clone()

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -412,7 +412,6 @@ async fn info(context: State<Arc<GloveContext>>) -> Json<ServiceInfo> {
 
 // TODO Reject for zero balance
 // TODO Reject if new vote request reaches max batch size limit for poll
-// TODO Reject polls for certain tracks based on config
 async fn vote(
     State(context): State<Arc<GloveContext>>,
     Json(signed_request): Json<SignedVoteRequest>


### PR DESCRIPTION
This replaces `subxt`'s retrieving of extrinsic information from the node endpoint, as that has proven to be unreliable for historical blocks.

Only the client's `verify-vote` command has been affected by this change.