### PR TITLE
`/poll-info` REST end-point for retrieving estimated mixing time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,7 +1234,7 @@ checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "client"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "client-interface"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "common",
@@ -1287,7 +1287,7 @@ checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "common"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "aws-nitro-enclaves-nsm-api",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "enclave"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "aws-nitro-enclaves-nsm-api",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "enclave-interface"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "common",
  "nix 0.27.1",
@@ -4701,7 +4701,7 @@ dependencies = [
 
 [[package]]
 name = "service"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -5611,7 +5611,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stress-tool"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 [workspace.package]
 homepage = "https://projectglove.io/"
 repository = "https://github.com/projectglove/glove-monorepo/"
-version = "0.0.10"
+version = "0.0.11"
 
 [workspace.dependencies]
 anyhow = "1.0.86"
@@ -29,7 +29,7 @@ serde = { version = "1.0.203", features = ["derive"] }
 serde_bytes = "0.11.14"
 serde_cbor = "0.11.2"
 serde_json = "1.0.117"
-serde_with = { version = "3.8.1", features = ["base64"] }
+serde_with = "3.8.1"
 parity-scale-codec = "3.6.12"
 bigdecimal = "0.4.3"
 clap = { version = "4.5.4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -241,6 +241,41 @@ If request body is invalid then a `422 Unprocessable Entity` is returned. If the
 request itself then a `400 Bad Request` is returned with a JSON object containing the error type (`error`) and 
 description (`description`). `429 Too Many Requests` can also be returned and the request should be retried later.
 
+## `GET /poll-info/{poll_index}`
+
+Get Glove-specific information about poll with index `poll_index`.
+
+### Request
+
+None
+
+### Response
+
+A JSON object with the following fields:
+
+#### `mixing_time`
+
+**Estimated** time the Glove service will mix vote requests and submit them on-chain. If the service hasn't received 
+requests for this poll then this is the time the service _would_ mix if it had. This field is only available for polls
+which have reached the decision phase. The mixing time isn't fixed and may change as the poll progresses. It is thus 
+recommended to occasionally poll this end-point.
+
+The time is given in terms of both block number and UNIX timestamp seconds; the value is an object with fields 
+`block_number` and `timestamp`. 
+
+If the poll is not active then `400 Bad Request` is returned.
+
+#### Example
+
+```json
+{
+  "mixing_time": {
+    "block_number": 22508946,
+    "timestamp": 1726170438
+  }
+}
+```
+
 # Client CLI
 
 There is a CLI client for interacting with the Glove service from the command line. It is built alongside the Glove

--- a/client-interface/src/lib.rs
+++ b/client-interface/src/lib.rs
@@ -197,6 +197,15 @@ impl SubstrateNetwork {
             .ok_or_else(|| SubxtError::Other("Current block number not available".into()))?;
         Ok(current_block_number)
     }
+
+    pub async fn current_time(&self) -> Result<u64, SubxtError> {
+        let current_time = self.api
+            .storage()
+            .at_latest().await?
+            .fetch(&storage().timestamp().now()).await?
+            .ok_or_else(|| SubxtError::Other("Current time not available".into()))?;
+        Ok(current_time)
+    }
 }
 
 impl Debug for SubstrateNetwork {

--- a/devops/ansible/roles/glove/templates/glove.service
+++ b/devops/ansible/roles/glove/templates/glove.service
@@ -3,7 +3,7 @@ Description=Glove Nitro service
 After=network.target
 
 [Service]
-ExecStart=/usr/local/glove/service --proxy-secret-phrase {{ glove_proxy_secret_phrase }} --address {{ glove_address }} --node-endpoint {{ glove_node_endpoint }} --regular-mix {% if glove_db == "dynamodb" %}
+ExecStart=/usr/local/glove/service --proxy-secret-phrase {{ glove_proxy_secret_phrase }} --address {{ glove_address }} --node-endpoint {{ glove_node_endpoint }} {% if glove_db == "dynamodb" %}
 dynamodb --table-name {{ glove_db_table }}
 {% else %}
 in-memory


### PR DESCRIPTION
The test deployment has been updated to not use the `--regular-mix` mode (which is not suitable for production). The end-point returns `404` if the flag is enabled.