### PR TITLE
Client no longer requires node endpoint and subxt reconnect fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,7 +1234,7 @@ checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "client"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "client-interface"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "anyhow",
  "common",
@@ -1287,7 +1287,7 @@ checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "common"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "aws-nitro-enclaves-nsm-api",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "enclave"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "anyhow",
  "aws-nitro-enclaves-nsm-api",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "enclave-interface"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "common",
  "nix 0.27.1",
@@ -4701,7 +4701,7 @@ dependencies = [
 
 [[package]]
 name = "service"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -5611,7 +5611,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stress-tool"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "anyhow",
  "clap",
@@ -5620,6 +5620,7 @@ dependencies = [
  "common",
  "rand",
  "reqwest",
+ "serde",
  "sp-runtime 37.0.0",
  "subxt-signer",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 [workspace.package]
 homepage = "https://projectglove.io/"
 repository = "https://github.com/projectglove/glove-monorepo/"
-version = "0.0.11"
+version = "0.0.12"
 
 [workspace.dependencies]
 anyhow = "1.0.86"

--- a/client-interface/Cargo.toml
+++ b/client-interface/Cargo.toml
@@ -12,7 +12,7 @@ anyhow.workspace = true
 sp-core.workspace = true
 sp-runtime.workspace = true
 ss58-registry.workspace = true
-subxt.workspace = true
+subxt = { workspace = true, features = ["unstable-reconnecting-rpc-client"] }
 subxt-core.workspace = true
 subxt-signer.workspace = true
 thiserror.workspace = true

--- a/stress-tool/Cargo.toml
+++ b/stress-tool/Cargo.toml
@@ -16,3 +16,4 @@ reqwest.workspace = true
 clap.workspace = true
 anyhow.workspace = true
 subxt-signer.workspace = true
+serde.workspace = true


### PR DESCRIPTION
Previously the client was incorrectly assuming a node endpoint of the form `wss://${network_name}-rpc.polkadot.io`. In particular, this doesn't hold for Polkadot and Kusama. The alternative of adding a node endpoint flag is not workable, as it would make the client harder to use, especially when it comes to verifying votes. Subscan is being used instead, which does have a consistent URL format.

The service has also been improved to deal with `RestartNeeded` errors coming from the RPC client in subxt. This was causing `/poll-info` and `/vote` to return `500 Internal Server Error`. The subxt RPC client will now try to automatically reconnect, and if that fails, the end-point will return `503 Service Unavailable` to indicate a temporary issue.