### PR TITLE
Test the node RPC endpoint in `/info`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 [workspace.package]
 homepage = "https://projectglove.io/"
 repository = "https://github.com/projectglove/glove-monorepo/"
-version = "0.0.12"
+version = "0.0.13"
 
 [workspace.dependencies]
 anyhow = "1.0.86"

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -392,13 +392,16 @@ async fn is_poll_ready_for_final_mix(
     }
 }
 
-async fn info(context: State<Arc<GloveContext>>) -> Json<ServiceInfo> {
-    Json(ServiceInfo {
+async fn info(context: State<Arc<GloveContext>>) -> Result<Json<ServiceInfo>, InternalError> {
+    // Make sure the RPC connection is still alive
+    let current_block_number = context.network.current_block_number().await?;
+    debug!("Current block number: {}", current_block_number);
+    Ok(Json(ServiceInfo {
         proxy_account: context.network.account(),
         network_name: context.network.network_name.clone(),
         attestation_bundle: context.attestation_bundle.clone(),
         version: env!("CARGO_PKG_VERSION").to_string()
-    })
+    }))
 }
 
 // TODO Reject for zero balance


### PR DESCRIPTION
`/info` gets the current block number from the node endpoint. This should keep the RPC connection alive (in case the subxt reconnect functionality isn't working) since `/info` is polled frequently as part of the health check. And if the subxt call errors then the health check will cause the service to restart.